### PR TITLE
Make OpenStack collections qualify for NewStylePlanner

### DIFF
--- a/ansible_mitogen/planner.py
+++ b/ansible_mitogen/planner.py
@@ -301,6 +301,9 @@ class NewStylePlanner(ScriptPlanner):
 
     @classmethod
     def detect(cls, path, source):
+        if b'from ansible_collections.openstack.' in source:
+            cls.marker = b'from ansible_collections.openstack.'
+        LOG.debug('cls.marker: %r, source: %r', cls.marker, source)
         return cls.marker in source
 
     def _get_interpreter(self):


### PR DESCRIPTION
To be detected as a NewStyle module mitogen expects that your module
imports ansible.module_utils. However the OpenStack collections modules
import a utility module which then imports ansible.module_utils.
Due to the naive way mitogen checks for this import the Openstack collections
modules do not qualify currently as being NewStyle as there is a layer of abstraction,
therefore causing them to fail down the line as they are run with the OldStylePlanner.
My fix is as equally naive!


Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.

